### PR TITLE
Cherry-pick bigswitch/nginx#1 to the newer version

### DIFF
--- a/src/core/ngx_inet.c
+++ b/src/core/ngx_inet.c
@@ -215,7 +215,8 @@ ngx_sock_ntop(struct sockaddr *sa, u_char *text, size_t len, ngx_uint_t port)
             text[n++] = '[';
         }
 
-        n = ngx_inet6_ntop(sin6->sin6_addr.s6_addr, &text[n], len);
+        n = ngx_inet6_ntop(sin6->sin6_addr.s6_addr, sin6->sin6_scope_id, 0,
+                           &text[n], len);
 
         if (port) {
             n = ngx_sprintf(&text[1 + n], "]:%d",
@@ -243,7 +244,8 @@ ngx_sock_ntop(struct sockaddr *sa, u_char *text, size_t len, ngx_uint_t port)
 
 
 size_t
-ngx_inet_ntop(int family, void *addr, u_char *text, size_t len)
+ngx_inet_ntop(int family, void *addr, int scope, int escape,
+              u_char *text, size_t len)
 {
     u_char  *p;
 
@@ -260,7 +262,7 @@ ngx_inet_ntop(int family, void *addr, u_char *text, size_t len)
 #if (NGX_HAVE_INET6)
 
     case AF_INET6:
-        return ngx_inet6_ntop(addr, text, len);
+        return ngx_inet6_ntop(addr, scope, escape, text, len);
 
 #endif
 
@@ -273,7 +275,8 @@ ngx_inet_ntop(int family, void *addr, u_char *text, size_t len)
 #if (NGX_HAVE_INET6)
 
 size_t
-ngx_inet6_ntop(u_char *p, u_char *text, size_t len)
+ngx_inet6_ntop(u_char *p, int s, int e,
+               u_char *text, size_t len)
 {
     u_char      *dst;
     size_t       max, n;
@@ -343,6 +346,14 @@ ngx_inet6_ntop(u_char *p, u_char *text, size_t len)
 
     if (n == 12) {
         dst = ngx_sprintf(dst, "%ud.%ud.%ud.%ud", p[12], p[13], p[14], p[15]);
+    }
+
+    if (s != 0) {
+        if (e) {
+            dst = ngx_sprintf(dst, "%%25%ud", s);
+        } else {
+            dst = ngx_sprintf(dst, "%%%ud", s);
+        }
     }
 
     return dst - text;

--- a/src/core/ngx_inet.h
+++ b/src/core/ngx_inet.h
@@ -23,7 +23,7 @@
 
 #define NGX_INET_ADDRSTRLEN   (sizeof("255.255.255.255") - 1)
 #define NGX_INET6_ADDRSTRLEN                                                 \
-    (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255") - 1)
+    (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255%2599") - 1)
 #define NGX_UNIX_ADDRSTRLEN                                                  \
     (sizeof(struct sockaddr_un) - offsetof(struct sockaddr_un, sun_path))
 
@@ -105,11 +105,13 @@ typedef struct {
 in_addr_t ngx_inet_addr(u_char *text, size_t len);
 #if (NGX_HAVE_INET6)
 ngx_int_t ngx_inet6_addr(u_char *p, size_t len, u_char *addr);
-size_t ngx_inet6_ntop(u_char *p, u_char *text, size_t len);
+size_t ngx_inet6_ntop(u_char *p, int scope, int escape,
+                      u_char *text, size_t len);
 #endif
 size_t ngx_sock_ntop(struct sockaddr *sa, u_char *text, size_t len,
     ngx_uint_t port);
-size_t ngx_inet_ntop(int family, void *addr, u_char *text, size_t len);
+size_t ngx_inet_ntop(int family, void *addr, int scope, int escape,
+                     u_char *text, size_t len);
 ngx_int_t ngx_ptocidr(ngx_str_t *text, ngx_cidr_t *cidr);
 ngx_int_t ngx_parse_addr(ngx_pool_t *pool, ngx_addr_t *addr, u_char *text,
     size_t len);

--- a/src/http/modules/ngx_http_access_module.c
+++ b/src/http/modules/ngx_http_access_module.c
@@ -194,9 +194,9 @@ ngx_http_access_inet6(ngx_http_request_t *r, ngx_http_access_loc_conf_t *alcf,
         u_char  mt[NGX_INET6_ADDRSTRLEN];
         u_char  at[NGX_INET6_ADDRSTRLEN];
 
-        cl = ngx_inet6_ntop(p, ct, NGX_INET6_ADDRSTRLEN);
-        ml = ngx_inet6_ntop(rule6[i].mask.s6_addr, mt, NGX_INET6_ADDRSTRLEN);
-        al = ngx_inet6_ntop(rule6[i].addr.s6_addr, at, NGX_INET6_ADDRSTRLEN);
+        cl = ngx_inet6_ntop(p, 0, 0, ct, NGX_INET6_ADDRSTRLEN);
+        ml = ngx_inet6_ntop(rule6[i].mask.s6_addr, 0, 0, mt, NGX_INET6_ADDRSTRLEN);
+        al = ngx_inet6_ntop(rule6[i].addr.s6_addr, 0, 0, at, NGX_INET6_ADDRSTRLEN);
 
         ngx_log_debug6(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                        "access: %*s %*s %*s", cl, ct, ml, mt, al, at);

--- a/src/http/ngx_http_upstream_round_robin.c
+++ b/src/http/ngx_http_upstream_round_robin.c
@@ -313,7 +313,11 @@ ngx_http_upstream_create_round_robin_peer(ngx_http_request_t *r,
                 return NGX_ERROR;
             }
 
-            len = ngx_inet_ntop(AF_INET, &ur->addrs[i], p, NGX_INET_ADDRSTRLEN);
+            /*
+             * XXX roth -- none of this code (see above,
+             * NGX_INET_ADDRSTRLEN) will work with IPv6
+             */
+            len = ngx_inet_ntop(AF_INET, &ur->addrs[i], 0, 0, p, NGX_INET_ADDRSTRLEN);
             len = ngx_sprintf(&p[len], ":%d", ur->port) - p;
 
             sin = ngx_pcalloc(r->pool, sizeof(struct sockaddr_in));


### PR DESCRIPTION
Reviewer: @carlroth @shudongz

Reference:
- bigswitch/nginx#1

Notes:
- There are no merge conflicts.
- There are no new usages of `ngx_inet_ntop()` and `ngx_inet6_ntop()` in this repository.
  - There are new usages of these in other modules though. Addressed elsewhere. 
